### PR TITLE
Plex data persistence 

### DIFF
--- a/ansible/plex_destroy.yml
+++ b/ansible/plex_destroy.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Playbook used to gracefully destroy Plex
+  hosts: all
+  remote_user: alfred
+  become: yes
+  vars:
+    workspace: stage
+  tasks:
+  - name: Stop Plex container
+    docker_container:
+      name: plex
+      state: stopped
+  - name: Stop Tautulli container
+    docker_container:
+      name: tautulli
+      state: stopped
+  - name: Run Plex config backup script
+    command: /home/plex/plex_backup.sh

--- a/ansible/roles/plex/tasks/main.yml
+++ b/ansible/roles/plex/tasks/main.yml
@@ -68,14 +68,26 @@
   delegate_to: "{{ inventory_hostname }}"
   when: plex_library.stat.exists == False
 
+- name: Import Plex config backup script
+  template:
+    src: plex_backup.sh.j2
+    dest: "{{ plex_config }}/plex_backup.sh"
+    mode: 0755
+    owner: "{{ plex_user }}"
+    group: "{{ plex_group }}"
+
+- name: Cron job to backup plex config
+  cron:
+    name: "backup plex config"
+    special_time: hourly
+    job: "{{ plex_config }}/plex_backup.sh"
+
 ## Mount shared EFS for PlexDrive config
 - name: "Create shared NFS mount point"
   file:
     state: directory
     path: "{{ plexdrive_config }}"
     mode: 0755
-    owner: "{{ plex_user }}"
-    group: "{{ plex_group }}"
 
 - name: "Mount shared EFS as NFS"
   mount:
@@ -90,9 +102,7 @@
   file:
     path: "{{ item }}"
     state: directory
-    mode: 0775
-    owner: "{{ plex_user }}"
-    group: "{{ plex_group }}"
+    mode: 0755
   with_items:
     - "{{ plex_data }}"
 
@@ -157,8 +167,8 @@
     image: "plexinc/pms-docker"
     name: "{{ docker_plex_container_name }}"
     env:
-      PUID: '1201'
-      PGID: '1201'
+      PLEX_UID: '1201'
+      PLEX_GID: '1201'
       VERSION: '{{ docker_plex_version }}'
     volumes:
       - '{{ plex_config }}/transcode:/transcode'

--- a/ansible/roles/plex/templates/plex_backup.sh.j2
+++ b/ansible/roles/plex/templates/plex_backup.sh.j2
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# redirect stdout/sterr to a log file
+exec &> {{ plex_shared_config }}/plex_backup.log
+
+echo "Starting Plex config backup - `date`"
+echo "Validating that local Plex config exists"
+
+if [ -f "{{ plex_config }}/config/Library/Application Support/Plex Media Server/Preferences.xml" ]; then
+  # the config exists
+  echo "The local Plex config EXISTS"
+
+  # Backup Plex local config directory to shared EFS
+  rsync -av --delete --exclude '*.pid'  {{ plex_config }}/config/ {{ plex_shared_config }}/config/
+else
+  # the config does not exists
+  echo "The local Plex config does NOT exist"
+fi

--- a/ansible/roles/plex/templates/plexdrive.service.j2
+++ b/ansible/roles/plex/templates/plexdrive.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/plexdrive -c {{ plexdrive_config }} -o allow_other -v 2 --max-chunks=200 --chunk-size=10M --chunk-load-ahead=6 --chunk-check-threads=4 --chunk-load-threads=4 mount {{ plex_data }}
+ExecStart=/usr/bin/plexdrive -c {{ plexdrive_config }} -o allow_other -v 2 --uid=1201 --gid=1201 --max-chunks=200 --chunk-size=10M --chunk-load-ahead=6 --chunk-check-threads=4 --chunk-load-threads=4 mount {{ plex_data }}
 ExecStop=/bin/fusermount -uz {{ plex_data }}
 Restart=on-abort
 

--- a/terraform/modules/common/aws/ec2/debian/input.tf
+++ b/terraform/modules/common/aws/ec2/debian/input.tf
@@ -11,5 +11,5 @@ variable "instance_type"    {}
 variable "name"             {}
 variable "instance_count"   {}
 variable "security_groups"  {type = "list"}
-variable "playbook"         {}
-variable "destroy"          {}
+variable "playbook"         {default = ""}
+variable "destroy"          {default = ""}

--- a/terraform/modules/common/aws/ec2/debian/input.tf
+++ b/terraform/modules/common/aws/ec2/debian/input.tf
@@ -12,3 +12,4 @@ variable "name"             {}
 variable "instance_count"   {}
 variable "security_groups"  {type = "list"}
 variable "playbook"         {}
+variable "destroy"          {}

--- a/terraform/modules/common/aws/ec2/debian/main.tf
+++ b/terraform/modules/common/aws/ec2/debian/main.tf
@@ -48,6 +48,10 @@ resource "aws_instance" "debian_ec2" {
 	provisioner "local-exec" {
     command = "${var.playbook == "" ? "sleep 60" : "sleep 90; ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${self.public_ip}, ${var.playbook} --extra-vars 'env=${var.env}' --vault-password-file ../../ansible/vault_pass.txt"}"
   }
+	provisioner "local-exec" {
+		command = "${var.destroy == "" ? "sleep 10" : "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${self.public_ip}, ${var.destroy} --extra-vars 'env=${var.env}' --vault-password-file ../../ansible/vault_pass.txt"}"
+		when = "destroy"
+	}
 
   lifecycle {
     ignore_changes = ["ami"]

--- a/terraform/modules/common/aws/ec2/debian/main.tf
+++ b/terraform/modules/common/aws/ec2/debian/main.tf
@@ -46,7 +46,7 @@ resource "aws_instance" "debian_ec2" {
   }
 
 	provisioner "local-exec" {
-    command = "${var.playbook == "" ? "sleep 60" : "sleep 120; ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${self.public_ip}, ${var.playbook} --extra-vars 'env=${var.env}' --vault-password-file ../../ansible/vault_pass.txt"}"
+    command = "${var.playbook == "" ? "sleep 60" : "sleep 90; ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${self.public_ip}, ${var.playbook} --extra-vars 'env=${var.env}' --vault-password-file ../../ansible/vault_pass.txt"}"
   }
 
   lifecycle {

--- a/terraform/modules/common/aws/ec2/ubuntu/input.tf
+++ b/terraform/modules/common/aws/ec2/ubuntu/input.tf
@@ -11,5 +11,5 @@ variable "instance_type"    {}
 variable "name"             {}
 variable "instance_count"   {}
 variable "security_groups"  {type = "list"}
-variable "playbook"         {}
-variable "destroy"          {}
+variable "playbook"         {default = ""}
+variable "destroy"          {default = ""}

--- a/terraform/modules/common/aws/ec2/ubuntu/input.tf
+++ b/terraform/modules/common/aws/ec2/ubuntu/input.tf
@@ -12,3 +12,4 @@ variable "name"             {}
 variable "instance_count"   {}
 variable "security_groups"  {type = "list"}
 variable "playbook"         {}
+variable "destroy"          {}

--- a/terraform/modules/common/aws/ec2/ubuntu/main.tf
+++ b/terraform/modules/common/aws/ec2/ubuntu/main.tf
@@ -46,7 +46,7 @@ resource "aws_instance" "ubuntu_ec2" {
   }
 
   provisioner "local-exec" {
-    command = "${var.playbook == "" ? "sleep 60" : "sleep 120; ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${self.public_ip}, ${var.playbook} --extra-vars 'env=${var.env}' --vault-password-file ../../ansible/vault_pass.txt"}"
+    command = "${var.playbook == "" ? "sleep 60" : "sleep 90; ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${self.public_ip}, ${var.playbook} --extra-vars 'env=${var.env}' --vault-password-file ../../ansible/vault_pass.txt"}"
   }
 
   lifecycle {

--- a/terraform/modules/common/aws/ec2/ubuntu/main.tf
+++ b/terraform/modules/common/aws/ec2/ubuntu/main.tf
@@ -48,6 +48,10 @@ resource "aws_instance" "ubuntu_ec2" {
   provisioner "local-exec" {
     command = "${var.playbook == "" ? "sleep 60" : "sleep 90; ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${self.public_ip}, ${var.playbook} --extra-vars 'env=${var.env}' --vault-password-file ../../ansible/vault_pass.txt"}"
   }
+	provisioner "local-exec" {
+		command = "${var.destroy == "" ? "sleep 10" : "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${self.public_ip}, ${var.destroy} --extra-vars 'env=${var.env}' --vault-password-file ../../ansible/vault_pass.txt"}"
+		when = "destroy"
+	}
 
   lifecycle {
     ignore_changes = ["ami"]

--- a/terraform/plex/plex.tf
+++ b/terraform/plex/plex.tf
@@ -45,7 +45,7 @@ module "plex_host" {
   env               = "${terraform.workspace}"
   subnet_id         = "${data.aws_subnet.plex_subnet.id}"
   public_ip         = "TRUE"
-  instance_type     = "c5.xlarge"
+  instance_type     = "c5.large"
   name              = "plex"
   instance_count    = 1
   security_groups   = [

--- a/terraform/plex/plex.tf
+++ b/terraform/plex/plex.tf
@@ -54,4 +54,5 @@ module "plex_host" {
     "${aws_security_group.sg_plex.id}"
   ]
   playbook          = "../../ansible/plex.yml"
+  destroy           = "../../ansible/plex_destroy.yml"
 }


### PR DESCRIPTION
- configure destroy time provisioner functionality on EC2 modules to help ensure data persistence maintained on "destroy"
- setup plex config with a destroy time provisioner
- configure automatic and periodic "backups" of plex config
- clean up uid, gid, and file permissions to minimize ansible drift
- correct plex container env variables
- downsize plex EC2 instance